### PR TITLE
Trivy scan

### DIFF
--- a/.github/workflows/build_test_fp.yaml
+++ b/.github/workflows/build_test_fp.yaml
@@ -62,6 +62,15 @@ jobs:
       run: |
         git clone --single-branch --branch main --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
   
+    - name: Run Trivy vulnerability scan - deps
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: 'awiciroh/forcingprocessor-deps:latest-x86'
+
+    - name: Run Trivy vulnerability scan - fp
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: 'awiciroh/forcingprocessor:latest-x86'
     - name: Prepare and test docker containers
       run: |
         cd ngen-datastream
@@ -75,16 +84,8 @@ jobs:
         fi
         echo $DS_TAG
         export DS_TAG=$DS_TAG FP_TAG=latest-x86 && ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/palisade.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json -n 4
-        
-    - name: Run Trivy vulnerability scan - deps
-      uses: aquasecurity/trivy-action@0.28.0
-      with:
-        image-ref: 'awiciroh/forcingprocessor-deps:latest-x86'
 
-    - name: Run Trivy vulnerability scan - fp
-      uses: aquasecurity/trivy-action@0.28.0
-      with:
-        image-ref: 'awiciroh/forcingprocessor:latest-x86'
+
 
   build-test-docker-arm:
     needs: [build-test-docker-x86]

--- a/.github/workflows/build_test_fp.yaml
+++ b/.github/workflows/build_test_fp.yaml
@@ -16,6 +16,7 @@ on:
     branches:
       - main
       - fp_workflow
+      - trivy_scan
     paths:
       - 'docker/**' 
       - 'src/forcingprocessor/**'

--- a/.github/workflows/build_test_fp.yaml
+++ b/.github/workflows/build_test_fp.yaml
@@ -75,7 +75,16 @@ jobs:
         fi
         echo $DS_TAG
         export DS_TAG=$DS_TAG FP_TAG=latest-x86 && ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/palisade.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json -n 4
+        
+    - name: Run Trivy vulnerability scan - deps
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: 'awiciroh/forcingprocessor-deps:latest-x86'
 
+    - name: Run Trivy vulnerability scan - fp
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: 'awiciroh/forcingprocessor:latest-x86'
 
   build-test-docker-arm:
     needs: [build-test-docker-x86]

--- a/.github/workflows/build_test_push_docker_fp_X86_arm_version_aware.yaml
+++ b/.github/workflows/build_test_push_docker_fp_X86_arm_version_aware.yaml
@@ -132,6 +132,18 @@ jobs:
         fi
         export DS_TAG=$DS_TAG FP_TAG=latest-x86 && ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/palisade.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json -n 4
 
+    - name: Run Trivy vulnerability scan - deps
+      if: needs.detect-changes.outputs.build_deps == 'true'
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: 'awiciroh/forcingprocessor-deps:latest-x86'
+
+    - name: Run Trivy vulnerability scan - fp
+      if: needs.detect-changes.outputs.build_fp == 'true'
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: 'awiciroh/forcingprocessor:latest-x86'
+
     - name: Push docker containers
       run: |
         if [ "${{ needs.detect-changes.outputs.build_deps }}" == "true" ]; then

--- a/.github/workflows/build_test_push_docker_fp_X86_arm_version_aware.yaml
+++ b/.github/workflows/build_test_push_docker_fp_X86_arm_version_aware.yaml
@@ -115,6 +115,18 @@ jobs:
         TAG=latest-x86 docker compose -f docker/docker-compose.yml build forcingprocessor
         docker images
 
+    - name: Run Trivy vulnerability scan - deps
+      if: needs.detect-changes.outputs.build_deps == 'true'
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: 'awiciroh/forcingprocessor-deps:latest-x86'
+
+    - name: Run Trivy vulnerability scan - fp
+      if: needs.detect-changes.outputs.build_fp == 'true'
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        image-ref: 'awiciroh/forcingprocessor:latest-x86'
+        
     - name: clone ngen
       run: |
         git clone --single-branch --branch main --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
@@ -132,17 +144,7 @@ jobs:
         fi
         export DS_TAG=$DS_TAG FP_TAG=latest-x86 && ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/palisade.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json -n 4
 
-    - name: Run Trivy vulnerability scan - deps
-      if: needs.detect-changes.outputs.build_deps == 'true'
-      uses: aquasecurity/trivy-action@0.28.0
-      with:
-        image-ref: 'awiciroh/forcingprocessor-deps:latest-x86'
 
-    - name: Run Trivy vulnerability scan - fp
-      if: needs.detect-changes.outputs.build_fp == 'true'
-      uses: aquasecurity/trivy-action@0.28.0
-      with:
-        image-ref: 'awiciroh/forcingprocessor:latest-x86'
 
     - name: Push docker containers
       run: |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       cache_from:
         - awiciroh/forcingprocessor-deps:latest
     image: awiciroh/forcingprocessor-deps:${TAG:-latest}
+    
   forcingprocessor:
     build:
       context: ..

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       cache_from:
         - awiciroh/forcingprocessor-deps:latest
     image: awiciroh/forcingprocessor-deps:${TAG:-latest}
-    
   forcingprocessor:
     build:
       context: ..


### PR DESCRIPTION
In the workflow, the Trivy steps scan the forcingprocessor-deps and forcingprocessor Docker images for known vulnerabilities after they are built. Trivy inspects OS packages and libraries inside the images, reporting issues by severity (Critical, High, Medium, Low). 

This integration adds an important security checkpoint to the CI process, ensuring that images are validated for both functionality and security before testing or deployment. It helps catch risks early, improves compliance, and aligns the pipeline with DevSecOps best practices.