### PR TITLE
Update ARM workflow to use datastreamcli and migrate runner to ngen-community account

### DIFF
--- a/.github/executions/fp_push_execution_arm.json
+++ b/.github/executions/fp_push_execution_arm.json
@@ -2,11 +2,11 @@
   "commands": [
     "runuser -l ec2-user -c 'rm -rf /home/ec2-user/ngen-datastream && docker rmi -f $(docker images -aq)'",
     "runuser -l ec2-user -c 'cd /home/ec2-user && git clone -b ${BRANCH_NAME} https://github.com/CIROH-UA/forcingprocessor.git'",
-    "runuser -l ec2-user -c 'cd /home/ec2-user/forcingprocessor && git clone https://github.com/CIROH-UA/ngen-datastream.git'",
+    "runuser -l ec2-user -c 'cd /home/ec2-user/forcingprocessor && git clone https://github.com/CIROH-UA/datastreamcli.git'",
     "runuser -l ec2-user -c 'ARCH=aarch64 TAG=latest-arm64 docker compose -f /home/ec2-user/forcingprocessor/docker/docker-compose.yml build forcingprocessor-deps' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",    
     "runuser -l ec2-user -c 'TAG=latest-arm64 docker compose -f /home/ec2-user/forcingprocessor/docker/docker-compose.yml build forcingprocessor' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",
     "runuser -l ec2-user -c 'docker images' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",
-    "runuser -l ec2-user -c 'export FP_TAG=latest-arm64 && /home/ec2-user/forcingprocessor/ngen-datastream/scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d /home/ec2-user/forcingprocessor/ngen-datastream/data/datastream_test -g https://ngen-datastream.s3.us-east-2.amazonaws.com/palisade.gpkg -R /home/ec2-user/forcingprocessor/ngen-datastream/configs/ngen/realization_sloth_nom_cfe_pet.json' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",
+    "runuser -l ec2-user -c 'export FP_TAG=latest-arm64 && /home/ec2-user/forcingprocessor/datastreamcli/scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d /home/ec2-user/forcingprocessor/datastreamcli/data/datastream_test -g https://ngen-datastream.s3.us-east-2.amazonaws.com/palisade.gpkg -R /home/ec2-user/forcingprocessor/datastreamcli/configs/ngen/realization_sloth_nom_cfe_pet.json' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",
     "runuser -l ec2-user -c 'chmod +x /home/ec2-user/forcingprocessor/docker/docker_loginNpush.sh'",
     "runuser -l ec2-user -c '/home/ec2-user/forcingprocessor/docker/docker_loginNpush.sh ${DEPS_TAG} ${FP_TAG} \"${BUILD_ARGS}\"' >> /home/ec2-user/forcingprocessor/docker_login_log.txt 2>&1",
     "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/forcingprocessor/docker_login_log.txt s3://ciroh-community-ngen-datastream/forcingprocessor/test/docker_login_log.txt'",

--- a/.github/workflows/build_test_fp_arm.yaml
+++ b/.github/workflows/build_test_fp_arm.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build-arm64:
-    runs-on: ubuntu-22.04-arm64
+    runs-on: ubuntu-22.04-arm-aws
     steps:
       - name: Pre-cleanup workspace
         continue-on-error: true
@@ -72,7 +72,7 @@ jobs:
 
   test-arm64:
     needs: build-arm64
-    runs-on: ubuntu-22.04-arm64
+    runs-on: ubuntu-22.04-arm-aws
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -188,7 +188,7 @@ jobs:
           
   cleanup-artifacts:
     needs: test-arm64
-    runs-on: ubuntu-22.04-arm64
+    runs-on: ubuntu-22.04-arm-aws
     if: always()
     steps:
       - name: Delete artifacts


### PR DESCRIPTION
This PR updates all references from the ngen-datastream repository to the current datastreamcli repository within the forcingprocessor ARM build and execution workflow. This ensures that the correct CLI repo is pulled and used during ARM testing.

Additionally, the GitHub Actions ARM runner reference has been updated to point to the runner hosted in the ngen-community AWS account instead of the UA AWS account. This transition centralizes ARM testing infrastructure under the community environment for better consistency and long-term maintainability. 