### PR TITLE
Fix ARM build execution to match production NRDS format

### DIFF
--- a/.github/executions/fp_push_execution_arm.json
+++ b/.github/executions/fp_push_execution_arm.json
@@ -6,16 +6,17 @@
     "runuser -l ec2-user -c 'ARCH=aarch64 TAG=latest-arm64 docker compose -f /home/ec2-user/forcingprocessor/docker/docker-compose.yml build forcingprocessor-deps' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",    
     "runuser -l ec2-user -c 'TAG=latest-arm64 docker compose -f /home/ec2-user/forcingprocessor/docker/docker-compose.yml build forcingprocessor' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",
     "runuser -l ec2-user -c 'docker images' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",
-    "runuser -l ec2-user -c 'export FP_TAG=latest-arm64 && /home/ec2-user/forcingprocessor/datastreamcli/scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d /home/ec2-user/forcingprocessor/datastreamcli/data/datastream_test -g https://ngen-datastream.s3.us-east-2.amazonaws.com/palisade.gpkg -R /home/ec2-user/forcingprocessor/datastreamcli/configs/ngen/realization_sloth_nom_cfe_pet.json' >> /home/ec2-user/forcingprocessor/docker_build_log.txt 2>&1",
+    "runuser -l ec2-user -c 'export FP_TAG=latest-arm64 && /home/ec2-user/forcingprocessor/datastreamcli/scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d /home/ec2-user/forcingprocessor/datastreamcli/data/datastream_test -g https://ngen-datastream.s3.us-east-2.amazonaws.com/palisade.gpkg -R /home/ec2-user/forcingprocessor/datastreamcli/configs/ngen/realization_sloth_nom_cfe_pet.json --s3_bucket ciroh-community-ngen-datastream --s3_prefix forcingprocessor/test --forcing_source NWM_RETRO_V3 2>&1 | tee -a /home/ec2-user/forcingprocessor/datastream_test_output.txt /home/ec2-user/forcingprocessor/docker_build_log.txt'",
     "runuser -l ec2-user -c 'chmod +x /home/ec2-user/forcingprocessor/docker/docker_loginNpush.sh'",
     "runuser -l ec2-user -c '/home/ec2-user/forcingprocessor/docker/docker_loginNpush.sh ${DEPS_TAG} ${FP_TAG} \"${BUILD_ARGS}\"' >> /home/ec2-user/forcingprocessor/docker_login_log.txt 2>&1",
     "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/forcingprocessor/docker_login_log.txt s3://ciroh-community-ngen-datastream/forcingprocessor/test/docker_login_log.txt'",
-    "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/forcingprocessor/docker_build_log.txt s3://ciroh-community-ngen-datastream/forcingprocessor/test/docker_build_log.txt'"
+    "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/forcingprocessor/docker_build_log.txt s3://ciroh-community-ngen-datastream/forcingprocessor/test/docker_build_log.txt'",
+    "runuser -l ec2-user -c 'aws s3 cp /home/ec2-user/forcingprocessor/datastream_test_output.txt s3://ciroh-community-ngen-datastream/forcingprocessor/test/datastream_test_output.txt'"
   ],
 "run_options":{
   "ii_terminate_instance" : true,
   "ii_delete_volume"      : true,
-  "ii_check_s3"           : false,
+  "ii_check_s3"           : true,
   "timeout_s"             : 3600,
   "n_retries_allowed"     : 2
 },


### PR DESCRIPTION
## Summary
Fixes Lambda `UnboundLocalError` in ARM build by adding required S3 flags.

Closes #41

## Changes
- Added `--s3_bucket ciroh-community-ngen-datastream`
- Added `--s3_prefix forcingprocessor/test`
- Added `--forcing_source NWM_RETRO_V3`
- Enabled `ii_check_s3: true`
- Added S3 upload for datastream test output

## Testing
Tested with run https://github.com/CIROH-UA/forcingprocessor/actions/runs/21531717656