### PR TITLE
Update forcingprocessor version to 2.0.0

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -1,2 +1,2 @@
-forcingprocessor: "1.0.2"
+forcingprocessor: "2.0.0"
 forcingprocessor-deps: "latest"


### PR DESCRIPTION
## Summary
- Updates forcingprocessor version from `1.0.2` to `2.0.0` in versions.yml

