### PR TITLE
pinned h5py version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     matplotlib
     netCDF4
     h5netcdf
-    h5py
+    h5py==3.11.0
     nwmurl==1.0.1
     pandas
     psutil


### PR DESCRIPTION
Closes #68 

## Changes

- pinned h5py to version 3.11.0

## Testing

1. Tested all existing pytests on macOS/arm64 and Ubuntu/x86

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux
