### PR TITLE
fix: use terraform output instead of sm_ARN.txt for state machine ARN

### DIFF
--- a/.github/workflows/integration_fp_ds_arm64.yaml
+++ b/.github/workflows/integration_fp_ds_arm64.yaml
@@ -44,6 +44,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - name: Configure AWS
         run: |
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -100,7 +102,7 @@ jobs:
         id: stepfunction_execution
         run : |
           cd ngen-datastream/infra/aws/terraform/modules/orchestration
-          execution_arn=$(aws stepfunctions start-execution --state-machine-arn $(cat ./sm_ARN.txt) --name docker_builder_$(env TZ=US/Eastern date +'%Y%m%d%H%M%S') --input "file://$GITHUB_WORKSPACE/.github/executions/fp_ds_test_execution_arm.json" --region us-east-1 --query 'executionArn' --output text)
+          execution_arn=$(aws stepfunctions start-execution --state-machine-arn $(terraform output -raw datastream_arn) --name docker_builder_$(env TZ=US/Eastern date +'%Y%m%d%H%M%S') --input "file://$GITHUB_WORKSPACE/.github/executions/fp_ds_test_execution_arm.json" --region us-east-1 --query 'executionArn' --output text)
           echo "Execution ARN: $execution_arn"
           echo "execution_arn=$execution_arn" >> $GITHUB_OUTPUT
           echo "$execution_arn" > $GITHUB_WORKSPACE/execution_arn.txt


### PR DESCRIPTION
## Summary

- Replaces `cat ./sm_ARN.txt` with `terraform output -raw datastream_arn` in the ARM integration workflow
- Adds `terraform_wrapper: false` to `setup-terraform` for clean output in command substitutions

The upstream `ngen-datastream` repo removed the `local_file` resource that created `sm_ARN.txt` (CIROH-UA/ngen-datastream#339), causing this workflow to fail. The state machine ARN is available via the `datastream_arn` terraform output instead.

## Test plan

- [ ] Re-run the ARM integration workflow and verify the step function execution starts successfully