### PR TITLE
fix: use terraform output instead of sm_ARN.txt for state machine ARN

### DIFF
--- a/.github/workflows/build_push_fp.yaml
+++ b/.github/workflows/build_push_fp.yaml
@@ -286,7 +286,7 @@ jobs:
       - name: clone ngen
         if: steps.prep_config.outputs.skip_arm_build != 'true'
         run: |
-          git clone --single-branch --branch main --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
+          git clone --single-branch --branch v2.2.0 --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
 
       - name: Build AWS Infra
         if: steps.prep_config.outputs.skip_arm_build != 'true'

--- a/.github/workflows/integration_fp_ds_arm64.yaml
+++ b/.github/workflows/integration_fp_ds_arm64.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: clone ngen
         run: |
-          git clone --single-branch --branch main --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
+          git clone --single-branch --branch v2.2.0 --depth 1 https://github.com/CIROH-UA/ngen-datastream.git
 
       - name: Build AWS Infra
         working-directory: ngen-datastream/infra/aws/terraform/modules/orchestration


### PR DESCRIPTION
## Summary

- Replaces `cat ./sm_ARN.txt` with `terraform output -raw datastream_arn` in the ARM integration workflow
- Adds `terraform_wrapper: false` to `setup-terraform` for clean output in command substitutions

The upstream `ngen-datastream` repo removed the `local_file` resource that created `sm_ARN.txt` (CIROH-UA/ngen-datastream#339), causing this workflow to fail. The state machine ARN is available via the `datastream_arn` terraform output instead.

Resolves https://github.com/CIROH-UA/forcingprocessor/issues/72
Resolves https://github.com/CIROH-UA/forcingprocessor/issues/75