### PR TITLE
Remove buildx from x86 build job

### DIFF
--- a/.github/workflows/build_push_fp.yaml
+++ b/.github/workflows/build_push_fp.yaml
@@ -132,12 +132,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: Configure AWS
       run: |
         aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
setup-buildx-action uses the docker-container driver which runs in an isolated container that cannot see locally built images. This causes the fp build to pull the stale deps image from Docker Hub instead of using the freshly built local one, failing with `uv: command not found`.

The x86 job does not need QEMU or buildx. Removing them lets docker compose use the default docker driver which sees local images.