### PR TITLE
Security: migrate workflows from static AWS keys to OIDC

### DIFF
--- a/.github/executions/fp_ds_test_execution_arm.json
+++ b/.github/executions/fp_ds_test_execution_arm.json
@@ -31,7 +31,11 @@
         "Tags": [
             {
                 "Key"   : "Name",
-                "Value" : "arm_docker_buildNtester"
+                "Value" : "ci_fp_integration_test_arm"
+            },
+            {
+                "Key"   : "Project",
+                "Value" : "ci_fp_integration_test_arm"
             }
         ]
     }

--- a/.github/executions/fp_push_execution_arm.json
+++ b/.github/executions/fp_push_execution_arm.json
@@ -35,7 +35,11 @@
         "Tags": [
             {
                 "Key"   : "Name",
-                "Value" : "arm_docker_buildNtester"
+                "Value" : "ci_fp_build_push_arm"
+            },
+            {
+                "Key"   : "Project",
+                "Value" : "ci_fp_build_push_arm"
             }
         ]
     }

--- a/.github/workflows/build_push_fp.yaml
+++ b/.github/workflows/build_push_fp.yaml
@@ -34,6 +34,7 @@ on:
       - '.python-version'
 
 permissions:
+  id-token: write
   contents: read
   security-events: write
 
@@ -132,12 +133,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Configure AWS
-      run: |
-        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws configure set region us-east-1
-         
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        aws-region: us-east-1
+
     - name: Build docker containers
       run: |
           if [ "${{ needs.detect-changes.outputs.build_deps }}" == "true" ]; then
@@ -214,11 +215,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1        
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)
       - name: Prepare execution config

--- a/.github/workflows/build_push_fp.yaml
+++ b/.github/workflows/build_push_fp.yaml
@@ -136,7 +136,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
 
@@ -219,7 +219,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)

--- a/.github/workflows/build_push_fp.yaml
+++ b/.github/workflows/build_push_fp.yaml
@@ -136,7 +136,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
 
@@ -219,7 +219,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)

--- a/.github/workflows/build_push_fp.yaml
+++ b/.github/workflows/build_push_fp.yaml
@@ -132,12 +132,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: Configure AWS
       run: |
         aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build_test_fp_arm.yaml
+++ b/.github/workflows/build_test_fp_arm.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build forcingprocessor-deps
@@ -185,7 +185,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run ${{ matrix.test-suite.name }}

--- a/.github/workflows/build_test_fp_arm.yaml
+++ b/.github/workflows/build_test_fp_arm.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build forcingprocessor-deps
@@ -185,7 +185,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run ${{ matrix.test-suite.name }}
@@ -194,9 +194,9 @@ jobs:
             -v $(pwd):/forcingprocessor \
             -w /forcingprocessor \
             -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
-            -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
+            -e "AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}" \
+            -e "AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}" \
+            -e "AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}" \
             awiciroh/${{ matrix.test-suite.image }}:latest-arm64 \
             ${{ matrix.test-suite.command }}
             

--- a/.github/workflows/build_test_fp_arm.yaml
+++ b/.github/workflows/build_test_fp_arm.yaml
@@ -22,6 +22,7 @@ on:
       - 'setup.cfg'
       - '.python-version'
 permissions:
+  id-token: write
   contents: read
   security-events: write
 
@@ -39,11 +40,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       - name: Build forcingprocessor-deps
         run: |
@@ -181,14 +182,21 @@ jobs:
           done
 
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Run ${{ matrix.test-suite.name }}
         run: |
           docker run --rm \
             -v $(pwd):/forcingprocessor \
             -w /forcingprocessor \
             -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
+            -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
+            -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
             awiciroh/${{ matrix.test-suite.image }}:latest-arm64 \
             ${{ matrix.test-suite.command }}
             

--- a/.github/workflows/build_test_fp_x86.yaml
+++ b/.github/workflows/build_test_fp_x86.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build forcingprocessor-deps
@@ -183,7 +183,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run ${{ matrix.test-suite.name }}

--- a/.github/workflows/build_test_fp_x86.yaml
+++ b/.github/workflows/build_test_fp_x86.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Build forcingprocessor-deps
@@ -183,7 +183,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Run ${{ matrix.test-suite.name }}
@@ -192,9 +192,9 @@ jobs:
             -v $(pwd):/forcingprocessor \
             -w /forcingprocessor \
             -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
-            -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
+            -e "AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}" \
+            -e "AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}" \
+            -e "AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}" \
             awiciroh/${{ matrix.test-suite.image }}:latest-x86 \
             ${{ matrix.test-suite.command }}
             

--- a/.github/workflows/build_test_fp_x86.yaml
+++ b/.github/workflows/build_test_fp_x86.yaml
@@ -24,6 +24,7 @@ on:
 
 
 permissions:
+  id-token: write
   contents: read
   security-events: write
 
@@ -40,11 +41,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       - name: Build forcingprocessor-deps
         run: |
@@ -179,14 +180,21 @@ jobs:
           done
 
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Run ${{ matrix.test-suite.name }}
         run: |
           docker run --rm \
             -v $(pwd):/forcingprocessor \
             -w /forcingprocessor \
             -e AWS_REGION=us-east-1 \
-            -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            -e AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }} \
+            -e AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }} \
+            -e AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }} \
             awiciroh/${{ matrix.test-suite.image }}:latest-x86 \
             ${{ matrix.test-suite.command }}
             

--- a/.github/workflows/forcingprocessor_nrds.yaml
+++ b/.github/workflows/forcingprocessor_nrds.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_nrds.yaml
+++ b/.github/workflows/forcingprocessor_nrds.yaml
@@ -24,6 +24,7 @@ on:
       - '.python-version'
 
 permissions:
+  id-token: write
   contents: read
 jobs:
   test-forcingprocessor:
@@ -41,12 +42,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1           
-          
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/forcingprocessor_nrds.yaml
+++ b/.github/workflows/forcingprocessor_nrds.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_output_opts.yaml
+++ b/.github/workflows/forcingprocessor_output_opts.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_output_opts.yaml
+++ b/.github/workflows/forcingprocessor_output_opts.yaml
@@ -24,6 +24,7 @@ on:
       - '.python-version'
 
 permissions:
+  id-token: write
   contents: read
 jobs:
   test-forcingprocessor:
@@ -41,12 +42,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1           
-          
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/forcingprocessor_output_opts.yaml
+++ b/.github/workflows/forcingprocessor_output_opts.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_plotting.yaml
+++ b/.github/workflows/forcingprocessor_plotting.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_plotting.yaml
+++ b/.github/workflows/forcingprocessor_plotting.yaml
@@ -24,6 +24,7 @@ on:
       - '.python-version'
 
 permissions:
+  id-token: write
   contents: read
 jobs:
   test-forcingprocessor:
@@ -41,12 +42,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1           
-          
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/forcingprocessor_plotting.yaml
+++ b/.github/workflows/forcingprocessor_plotting.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_sources_nomads.yaml
+++ b/.github/workflows/forcingprocessor_sources_nomads.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_sources_nomads.yaml
+++ b/.github/workflows/forcingprocessor_sources_nomads.yaml
@@ -24,6 +24,7 @@ on:
       - '.python-version'
 
 permissions:
+  id-token: write
   contents: read
 jobs:
   test-forcingprocessor:
@@ -41,12 +42,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1           
-          
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/forcingprocessor_sources_nomads.yaml
+++ b/.github/workflows/forcingprocessor_sources_nomads.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_sources_nwm_aws.yaml
+++ b/.github/workflows/forcingprocessor_sources_nwm_aws.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_sources_nwm_aws.yaml
+++ b/.github/workflows/forcingprocessor_sources_nwm_aws.yaml
@@ -24,6 +24,7 @@ on:
       - '.python-version'
 
 permissions:
+  id-token: write
   contents: read
 jobs:
   test-forcingprocessor:
@@ -41,11 +42,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1           
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/forcingprocessor_sources_nwm_aws.yaml
+++ b/.github/workflows/forcingprocessor_sources_nwm_aws.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_sources_nwm_google.yaml
+++ b/.github/workflows/forcingprocessor_sources_nwm_google.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_sources_nwm_google.yaml
+++ b/.github/workflows/forcingprocessor_sources_nwm_google.yaml
@@ -24,6 +24,7 @@ on:
       - '.python-version'
 
 permissions:
+  id-token: write
   contents: read
 jobs:
   test-forcingprocessor:
@@ -41,12 +42,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1           
-          
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/forcingprocessor_sources_nwm_google.yaml
+++ b/.github/workflows/forcingprocessor_sources_nwm_google.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_weights.yaml
+++ b/.github/workflows/forcingprocessor_weights.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/forcingprocessor_weights.yaml
+++ b/.github/workflows/forcingprocessor_weights.yaml
@@ -24,6 +24,7 @@ on:
       - '.python-version'
 
 permissions:
+  id-token: write
   contents: read
 jobs:
   test-forcingprocessor:
@@ -41,12 +42,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1           
-          
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/forcingprocessor_weights.yaml
+++ b/.github/workflows/forcingprocessor_weights.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Install dependencies

--- a/.github/workflows/integration_fp_ds_arm64.yaml
+++ b/.github/workflows/integration_fp_ds_arm64.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)

--- a/.github/workflows/integration_fp_ds_arm64.yaml
+++ b/.github/workflows/integration_fp_ds_arm64.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)

--- a/.github/workflows/integration_fp_ds_arm64.yaml
+++ b/.github/workflows/integration_fp_ds_arm64.yaml
@@ -43,10 +43,11 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  id-token: write
   contents: read
   security-events: write
 
-jobs:    
+jobs:
   build-test-docker-arm:
     runs-on: ubuntu-latest
     steps:
@@ -56,11 +57,11 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-      - name: Configure AWS
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set region us-east-1        
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+          aws-region: us-east-1
 
       # Dynamically configures the test execution JSON by setting the branch name and conditionally removing Docker build commands for containers whose Dockerfiles haven't changed (optimization only applies to push events, not manual triggers)
       - name: Prepare execution config

--- a/.github/workflows/integration_fp_ds_x86.yaml
+++ b/.github/workflows/integration_fp_ds_x86.yaml
@@ -43,6 +43,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  id-token: write
   contents: read
   security-events: write
 
@@ -57,13 +58,13 @@ jobs:
       uses: docker/login-action@v3
       with:
         username: ${{secrets.DOCKERHUB_USERNAME}}
-        password: ${{secrets.DOCKERHUB_TOKEN}}        
+        password: ${{secrets.DOCKERHUB_TOKEN}}
 
-    - name: Configure AWS
-      run: |
-        aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws configure set region us-east-1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        aws-region: us-east-1
         
     # - name: Install packages for datastream
     #   run: |

--- a/.github/workflows/integration_fp_ds_x86.yaml
+++ b/.github/workflows/integration_fp_ds_x86.yaml
@@ -63,7 +63,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
         aws-region: us-east-1
         
     # - name: Install packages for datastream

--- a/.github/workflows/integration_fp_ds_x86.yaml
+++ b/.github/workflows/integration_fp_ds_x86.yaml
@@ -63,7 +63,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::879381264451:role/github-actions-terraform-oidc
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: us-east-1
         
     # - name: Install packages for datastream


### PR DESCRIPTION
- Replace static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets with OIDC via `aws-actions/configure-aws-credentials@v4`
- Add `id-token: write` permission to all AWS-authenticated workflows
- Add `AWS_SESSION_TOKEN` for Docker container credential passthrough
- Role: `github-actions-terraform-oidc`