### PR TITLE
update palisade.gpkg URL in test to community bucket

### DIFF
--- a/.github/workflows/build_push_fp.yaml
+++ b/.github/workflows/build_push_fp.yaml
@@ -26,12 +26,16 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/build_push_fp.yaml'
+      - '.github/executions/fp_push_execution_arm.json'
   pull_request:
     paths:
       - 'versions.yml'
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/build_push_fp.yaml'
+      - '.github/executions/fp_push_execution_arm.json'
 
 permissions:
   id-token: write

--- a/.github/workflows/build_test_fp_arm.yaml
+++ b/.github/workflows/build_test_fp_arm.yaml
@@ -13,6 +13,8 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/build_test_fp_arm.yaml'
+      - 'tests/test_hf2ds.py'
   pull_request:
     paths:
       - 'docker/**'
@@ -21,6 +23,8 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/build_test_fp_arm.yaml'
+      - 'tests/test_hf2ds.py'
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/build_test_fp_x86.yaml
+++ b/.github/workflows/build_test_fp_x86.yaml
@@ -13,6 +13,8 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/build_test_fp_x86.yaml'
+      - 'tests/test_hf2ds.py'
   pull_request:
     paths:
       - 'docker/**'
@@ -21,6 +23,8 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/build_test_fp_x86.yaml'
+      - 'tests/test_hf2ds.py'
 
 
 permissions:

--- a/.github/workflows/forcingprocessor_weights.yaml
+++ b/.github/workflows/forcingprocessor_weights.yaml
@@ -13,6 +13,8 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_weights.yaml'
+      - 'tests/test_hf2ds.py'
   pull_request:
     branches:
       - main
@@ -22,6 +24,8 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_weights.yaml'
+      - 'tests/test_hf2ds.py'
 
 permissions:
   id-token: write

--- a/.github/workflows/integration_fp_ds_arm64.yaml
+++ b/.github/workflows/integration_fp_ds_arm64.yaml
@@ -29,6 +29,8 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/integration_fp_ds_arm64.yaml'
+      - '.github/executions/fp_ds_test_execution_arm.json'
   pull_request:
     paths:
       - 'docker/**'
@@ -37,6 +39,8 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/integration_fp_ds_arm64.yaml'
+      - '.github/executions/fp_ds_test_execution_arm.json'
   
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration_fp_ds_x86.yaml
+++ b/.github/workflows/integration_fp_ds_x86.yaml
@@ -29,6 +29,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/integration_fp_ds_x86.yaml'
   pull_request:
     paths:
       - 'docker/**'
@@ -37,6 +38,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/integration_fp_ds_x86.yaml'
   
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tests/test_hf2ds.py
+++ b/tests/test_hf2ds.py
@@ -21,7 +21,7 @@ def test_parquet_v21():
     # assert len(weights) > 0
 
 def test_gpkg_v21():
-    os.system(f"curl -o {gpkg_path} -L -O https://ngen-datastream.s3.us-east-2.amazonaws.com/{geopackage_name}")
+    os.system(f"curl -o {gpkg_path} -L -O https://ciroh-community-ngen-datastream.s3.amazonaws.com/resources/v2.1_hydrofabric/geopackages/test_data/{geopackage_name}")
     weights,_ = hf2ds([gpkg_path],raster,1)
     assert len(weights) > 0
 
@@ -36,7 +36,7 @@ def test_multiple_parquet_v21():
     # assert len(weights) > 0
 
 def test_multiple_gpkg_v21():
-    os.system(f"curl -o {gpkg_path} -L -O https://ngen-datastream.s3.us-east-2.amazonaws.com/{geopackage_name}")
+    os.system(f"curl -o {gpkg_path} -L -O https://ciroh-community-ngen-datastream.s3.amazonaws.com/resources/v2.1_hydrofabric/geopackages/test_data/{geopackage_name}")
     weights,_ = hf2ds([gpkg_path,gpkg_path],raster,1)
     assert len(weights) > 0
 
@@ -51,7 +51,7 @@ def test_multiple_multiprocess_parquet_v21():
     # assert len(weights) > 0
 
 def test_multiple_multiprocess_gpkg_v21():
-    os.system(f"curl -o {gpkg_path} -L -O https://ngen-datastream.s3.us-east-2.amazonaws.com/{geopackage_name}")
+    os.system(f"curl -o {gpkg_path} -L -O https://ciroh-community-ngen-datastream.s3.amazonaws.com/resources/v2.1_hydrofabric/geopackages/test_data/{geopackage_name}")
     weights,_ = multiprocess_hf2ds([gpkg_path,gpkg_path],raster,2)
     assert len(weights) > 0
 


### PR DESCRIPTION
Updates the dead ngen-datastream.s3.us-east-2 URL in tests/test_hf2ds.py to the community bucket equivalent.