### PR TITLE
Add editable install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ uv venv
 ```
 uv pip install -r pyproject.toml
 ```
+## Install ForcingProcessor as a Module
+
+```bash
+uv pip install -e .
+```
+
+This is required for running:
+
+```bash
+python -m forcingprocessor.processor <config_file>
+```
+
 ## Create Output Directory
 ```
 mkdir -p data/forcing

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ uv pip install -r pyproject.toml
 uv pip install -e .
 ```
 
-This is required for running:
-
-```bash
-python -m forcingprocessor.processor <config_file>
-```
-
 ## Create Output Directory
 ```
 mkdir -p data/forcing


### PR DESCRIPTION
## Summary
Adds instructions to install `forcingprocessor` as a Python module using:

```bash
uv pip install -e .
```