### PR TITLE
Publish Docker images to GHCR

### DIFF
--- a/.github/workflows/build_push_fp.yaml
+++ b/.github/workflows/build_push_fp.yaml
@@ -41,6 +41,7 @@ permissions:
   id-token: write
   contents: read
   security-events: write
+  packages: write
 
 jobs:
   detect-changes:
@@ -194,20 +195,37 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Login to GHCR
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && (inputs.force_build_deps != '' || inputs.force_build_fp != ''))
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Push docker containers
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && (inputs.force_build_deps != '' || inputs.force_build_fp != ''))
       run: |
         if [ "${{ needs.detect-changes.outputs.build_deps }}" == "true" ]; then
-          VERSION_TAG="${{ needs.detect-changes.outputs.deps_version }}"
-          docker tag awiciroh/forcingprocessor-deps:latest-x86 awiciroh/forcingprocessor-deps:${VERSION_TAG}-x86
-          docker push awiciroh/forcingprocessor-deps:${VERSION_TAG}-x86
+          docker tag awiciroh/forcingprocessor-deps:latest-x86 awiciroh/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-x86
+          docker push awiciroh/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-x86
           docker push awiciroh/forcingprocessor-deps:latest-x86
+
+          docker tag awiciroh/forcingprocessor-deps:latest-x86 ghcr.io/ciroh-ua/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-x86
+          docker tag awiciroh/forcingprocessor-deps:latest-x86 ghcr.io/ciroh-ua/forcingprocessor-deps:latest-x86
+          docker push ghcr.io/ciroh-ua/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-x86
+          docker push ghcr.io/ciroh-ua/forcingprocessor-deps:latest-x86
         fi
+
         if [ "${{ needs.detect-changes.outputs.build_fp }}" == "true" ]; then
-          VERSION_TAG="${{ needs.detect-changes.outputs.fp_version }}"
-          docker tag awiciroh/forcingprocessor:latest-x86 awiciroh/forcingprocessor:${VERSION_TAG}-x86
-          docker push awiciroh/forcingprocessor:${VERSION_TAG}-x86
+          docker tag awiciroh/forcingprocessor:latest-x86 awiciroh/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-x86
+          docker push awiciroh/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-x86
           docker push awiciroh/forcingprocessor:latest-x86
+
+          docker tag awiciroh/forcingprocessor:latest-x86 ghcr.io/ciroh-ua/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-x86
+          docker tag awiciroh/forcingprocessor:latest-x86 ghcr.io/ciroh-ua/forcingprocessor:latest-x86
+          docker push ghcr.io/ciroh-ua/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-x86
+          docker push ghcr.io/ciroh-ua/forcingprocessor:latest-x86
         fi
 
 
@@ -411,6 +429,35 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror ARM images to GHCR
+        run: |
+          if [ "${{ needs.detect-changes.outputs.build_deps }}" == "true" ]; then
+            docker pull awiciroh/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-arm64
+            docker tag awiciroh/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-arm64 ghcr.io/ciroh-ua/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-arm64
+            docker push ghcr.io/ciroh-ua/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-arm64
+
+            docker pull awiciroh/forcingprocessor-deps:latest-arm64
+            docker tag awiciroh/forcingprocessor-deps:latest-arm64 ghcr.io/ciroh-ua/forcingprocessor-deps:latest-arm64
+            docker push ghcr.io/ciroh-ua/forcingprocessor-deps:latest-arm64
+          fi
+
+          if [ "${{ needs.detect-changes.outputs.build_fp }}" == "true" ]; then
+            docker pull awiciroh/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-arm64
+            docker tag awiciroh/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-arm64 ghcr.io/ciroh-ua/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-arm64
+            docker push ghcr.io/ciroh-ua/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-arm64
+
+            docker pull awiciroh/forcingprocessor:latest-arm64
+            docker tag awiciroh/forcingprocessor:latest-arm64 ghcr.io/ciroh-ua/forcingprocessor:latest-arm64
+            docker push ghcr.io/ciroh-ua/forcingprocessor:latest-arm64
+          fi
           
       - name: Create and push manifest forcingprocessor-deps
         if: needs.detect-changes.outputs.build_deps == 'true'
@@ -424,6 +471,16 @@ jobs:
             --amend awiciroh/forcingprocessor-deps:latest-x86 \
             --amend awiciroh/forcingprocessor-deps:latest-arm64
           docker manifest push awiciroh/forcingprocessor-deps:latest
+
+          docker manifest create ghcr.io/ciroh-ua/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }} \
+            --amend ghcr.io/ciroh-ua/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-x86 \
+            --amend ghcr.io/ciroh-ua/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}-arm64
+          docker manifest push ghcr.io/ciroh-ua/forcingprocessor-deps:${{ needs.detect-changes.outputs.deps_version }}
+
+          docker manifest create ghcr.io/ciroh-ua/forcingprocessor-deps:latest \
+            --amend ghcr.io/ciroh-ua/forcingprocessor-deps:latest-x86 \
+            --amend ghcr.io/ciroh-ua/forcingprocessor-deps:latest-arm64
+          docker manifest push ghcr.io/ciroh-ua/forcingprocessor-deps:latest
  
 
       - name: Create and push manifest forcingprocessor
@@ -438,3 +495,13 @@ jobs:
             --amend awiciroh/forcingprocessor:latest-x86 \
             --amend awiciroh/forcingprocessor:latest-arm64
           docker manifest push awiciroh/forcingprocessor:latest
+
+          docker manifest create ghcr.io/ciroh-ua/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }} \
+            --amend ghcr.io/ciroh-ua/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-x86 \
+            --amend ghcr.io/ciroh-ua/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}-arm64
+          docker manifest push ghcr.io/ciroh-ua/forcingprocessor:${{ needs.detect-changes.outputs.fp_version }}
+
+          docker manifest create ghcr.io/ciroh-ua/forcingprocessor:latest \
+            --amend ghcr.io/ciroh-ua/forcingprocessor:latest-x86 \
+            --amend ghcr.io/ciroh-ua/forcingprocessor:latest-arm64
+          docker manifest push ghcr.io/ciroh-ua/forcingprocessor:latest

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ uv venv
 ```
 uv pip install -r pyproject.toml
 ```
+## Install ForcingProcessor as a Module
+
+```bash
+uv pip install -e .
+```
+
+This is required for running:
+
+```bash
+python -m forcingprocessor.processor <config_file>
+```
+
 ## Create Output Directory
 ```
 mkdir -p data/forcing

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ uv pip install -r pyproject.toml
 uv pip install -e .
 ```
 
-This is required for running:
-
-```bash
-python -m forcingprocessor.processor <config_file>
-```
-
 ## Create Output Directory
 ```
 mkdir -p data/forcing


### PR DESCRIPTION
## Summary

Adds GitHub Container Registry (GHCR) publishing to the Docker build workflow.

### Changes
- Added `packages: write` permission for GHCR publishing
- Added GHCR authentication to workflow
- Push x86 images to both Docker Hub and GHCR
- Mirror ARM images from Docker Hub to GHCR during manifest creation
- Create and publish multi-architecture manifests in GHCR

This preserves the existing Docker Hub publishing workflow while adding GHCR support.