### PR TITLE
Trigger test workflows on changes to their own files

### DIFF
--- a/.github/workflows/forcingprocessor_nrds.yaml
+++ b/.github/workflows/forcingprocessor_nrds.yaml
@@ -13,6 +13,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_nrds.yaml'
   pull_request:
     branches:
       - main
@@ -22,6 +23,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_nrds.yaml'
 
 permissions:
   id-token: write

--- a/.github/workflows/forcingprocessor_output_opts.yaml
+++ b/.github/workflows/forcingprocessor_output_opts.yaml
@@ -13,6 +13,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_output_opts.yaml'
   pull_request:
     branches:
       - main
@@ -22,6 +23,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_output_opts.yaml'
 
 permissions:
   id-token: write

--- a/.github/workflows/forcingprocessor_plotting.yaml
+++ b/.github/workflows/forcingprocessor_plotting.yaml
@@ -13,6 +13,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_plotting.yaml'
   pull_request:
     branches:
       - main
@@ -22,6 +23,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_plotting.yaml'
 
 permissions:
   id-token: write

--- a/.github/workflows/forcingprocessor_sources_nomads.yaml
+++ b/.github/workflows/forcingprocessor_sources_nomads.yaml
@@ -13,6 +13,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_sources_nomads.yaml'
   pull_request:
     branches:
       - main
@@ -22,6 +23,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_sources_nomads.yaml'
 
 permissions:
   id-token: write

--- a/.github/workflows/forcingprocessor_sources_nwm_aws.yaml
+++ b/.github/workflows/forcingprocessor_sources_nwm_aws.yaml
@@ -13,6 +13,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_sources_nwm_aws.yaml'
   pull_request:
     branches:
       - main
@@ -22,6 +23,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_sources_nwm_aws.yaml'
 
 permissions:
   id-token: write

--- a/.github/workflows/forcingprocessor_sources_nwm_google.yaml
+++ b/.github/workflows/forcingprocessor_sources_nwm_google.yaml
@@ -13,6 +13,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_sources_nwm_google.yaml'
   pull_request:
     branches:
       - main
@@ -22,6 +23,7 @@ on:
       - 'pyproject.toml'
       - 'setup.cfg'
       - '.python-version'
+      - '.github/workflows/forcingprocessor_sources_nwm_google.yaml'
 
 permissions:
   id-token: write


### PR DESCRIPTION
Adds each workflow's own path to its `push`/`pull_request` path filters so edits to a workflow trigger that workflow. Applied to the 6 test workflows missing it; build/integration/weights workflows already had it.

Closes #88