### PR TITLE
Update integration test to v2.2 hydrofabric

### DIFF
--- a/.github/workflows/integration_fp_ds_x86.yaml
+++ b/.github/workflows/integration_fp_ds_x86.yaml
@@ -93,5 +93,5 @@ jobs:
         FP_TAG: ${{ inputs.fp_tag || 'latest-x86' }}
       run : |
         docker images
-        curl -L -O https://communityhydrofabric.s3.us-east-1.amazonaws.com/hydrofabrics/community/VPU/vpu-09_subset.gpkg
-        ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/vpu-09_subset.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json
+        curl -L -O https://ciroh-community-ngen-datastream.s3.amazonaws.com/resources/v2.2_hydrofabric/geopackages/test_data/palisade.gpkg
+        ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/palisade.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json

--- a/.github/workflows/integration_fp_ds_x86.yaml
+++ b/.github/workflows/integration_fp_ds_x86.yaml
@@ -93,5 +93,5 @@ jobs:
         FP_TAG: ${{ inputs.fp_tag || 'latest-x86' }}
       run : |
         docker images
-        curl -L -O https://ciroh-community-ngen-datastream.s3.amazonaws.com/resources/v2.1_hydrofabric/geopackages/test_data/palisade.gpkg
-        ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/palisade.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json
+        curl -L -O https://communityhydrofabric.s3.us-east-1.amazonaws.com/hydrofabrics/community/VPU/vpu-09_subset.gpkg
+        ./scripts/datastream -s 202006200100 -e 202006200200 -C NWM_RETRO_V3 -d $(pwd)/data/datastream_test -g $(pwd)/vpu-09_subset.gpkg -R $(pwd)/configs/ngen/realization_sloth_nom_cfe_pet.json


### PR DESCRIPTION
Updates the DataStreamCLI integration test to use the existing v2.2 community hydrofabric vpu-09_subset.gpkg instead of the v2.1 palisade.gpkg. 

PR for #101 